### PR TITLE
Add mime type for WGSL files

### DIFF
--- a/libs/server.ts
+++ b/libs/server.ts
@@ -41,6 +41,7 @@ const mimeTypes = {
     ".mp4": "video/mp4",
     ".webm": "video/webm",
     ".webp": "image/webp",
+    ".wgsl": "text/wgsl",
     ".ico": "image/x-icon",
     ".tiff": "image/tiff",
     ".gz": "application/gzip",


### PR DESCRIPTION
This PR adds a mime-type for WebGPU Shading Language files, which fixes a crash when a WGSL file is included in one of the public directories. (Let me know if you'd like me to add an issue for that and reference it here.)