### PR TITLE
add transform css

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "lerna run --parallel build",
     "preview": "lerna run --parallel preview",
     "publish": "lerna run --parallel build-npm",
-    "public": "lerna run --parallel publish",
+    "public": "lerna run publish --scope=vite-multiple-assets",
     "e2e": "npx playwright test"
   },
   "devDependencies": {

--- a/packages/examples/react/src/App.spec.tsx
+++ b/packages/examples/react/src/App.spec.tsx
@@ -30,7 +30,7 @@ test.describe('Test load multiple assets', () => {
     })
 
     test('Check load success css background-image', async ({page}) => {
-        const body = await page.$('body');
+        const body = await page.$('.bg-image');
         const backgroundImage = await body!.evaluate((el) =>
             window.getComputedStyle(el).getPropertyValue('background-image')
         );

--- a/packages/examples/react/src/App.spec.tsx
+++ b/packages/examples/react/src/App.spec.tsx
@@ -28,4 +28,19 @@ test.describe('Test load multiple assets', () => {
     test('Check loaded success image symlink', async ({page}) => {
         await expect(page.locator('[aria-label=logo-assets-symlink]')).not.toHaveJSProperty("naturalWidth", 0);
     })
+
+    test('Check load success css background-image', async ({page}) => {
+        const body = await page.$('body');
+        const backgroundImage = await body!.evaluate((el) =>
+            window.getComputedStyle(el).getPropertyValue('background-image')
+        );
+        const imageUrl = backgroundImage.match(/url\("(.*)"\)/)?.[1];
+        if (imageUrl) {
+            const [response] = await Promise.all([
+                page.waitForResponse((res) => res.url() === imageUrl && res.status() === 200),
+                page.goto(imageUrl)
+            ]);
+            expect(response.status()).toBe(200);
+        }
+    })
 })

--- a/packages/examples/react/src/App.tsx
+++ b/packages/examples/react/src/App.tsx
@@ -1,54 +1,57 @@
-import {useState} from 'react'
-import reactLogo from './assets/react.svg'
-// import viteLogo from '/vite.svg'
 import './App.css'
-import {Button} from "@mantine/core";
+import {Code, Grid} from "@mantine/core";
+import {CardImage} from "./CardImage.tsx";
 
 function App() {
-    const [count, setCount] = useState(0)
-
     return (
         <>
-            <div>
-                <a href="https://vitejs.dev" target="_blank">
-                    <img aria-label={"logo-assets"} src={"/base/shared/images/vite.svg"} className="logo"
-                         alt="Vite logo"/>
-                    <img aria-label={"img-output-subfolder"} src={"/base/shared/images/sub-folder/sub-image.png"}
-                         className="logo"
-                         alt="Vite logo"/>
-                    <img aria-label={"img-output-nested-subfolder"}
-                         src={"/base/shared/images/sub-folder/nested-sub-folder/sub-image1.png"}
-                         className="logo"
-                         alt="Vite logo"/>
-                    <img aria-label={"img-base"} src={"/base/images/settings.png"} className="logo" alt="Vite logo"/>
+            <Grid>
+                <CardImage col={{span:12}} titleCard={"Background image css"} images={[]}>
+                    <div style={{height:100,width:100,position:'relative'}}>
 
-                    <img aria-label={"img-base-with-parent"} src={"/base/public2/images/settings.png"} className="logo"
-                         alt="Vite logo"/>
-                    <img aria-label={"logo-assets-symlink"} src={"/base/shared/images/change1.png"} className="logo"
-                         alt="Vite logo"/>
-                </a>
-                <a href="https://react.dev" target="_blank">
-                    <img src={reactLogo} className="logo react" alt="React logo"/>
-                </a>
-            </div>
-            <Button w={{
-                sm: '100px',
-                lg: '200px'
-            }}>
-                HIII
-            </Button>
-            <h1>Vite + React</h1>
-            <div className="card">
-                <button onClick={() => setCount((count) => count + 1)}>
-                    count is {count}
-                </button>
-                <p>
-                    Edit <code>src/App.tsx</code> and save to test HMR
-                </p>
-            </div>
-            <p className="read-the-docs">
-                Click on the Vite and React logos to learn more
-            </p>
+                            <div className={"bg-image"}>
+
+                            </div>
+
+                    </div>
+                </CardImage>
+                <CardImage titleCard={`Image with sub folder`} description={<>
+                    From folder <Code>shared-assets</Code>
+                </>} images={[{
+                    src: "/base/shared/images/sub-folder/sub-image.png",
+                    alt: "Vite logo",
+                    className: "logo",
+                    "aria-label": "img-output-subfolder"
+                }, {
+                    src: "/base/shared/images/sub-folder/nested-sub-folder/sub-image1.png",
+                    alt: "Vite logo",
+                    className: "logo",
+                    "aria-label": "img-output-nested-subfolder"
+                }, {
+                    src: "/base/shared/images/vite.svg",
+                    alt: "Vite logo",
+                    className: "logo",
+                    "aria-label": "logo-assets"
+                }]}/>
+                <CardImage titleCard={"Image Base"} description={<>
+                    From folder <Code>public</Code></>} images={[{
+                    src: "/base/images/settings.png",
+                    "aria-label": "img-base",
+                    className: "logo"
+                }]}/>
+                <CardImage titleCard={"Image with parent folder"} images={[{
+                    src: "/base/public2/images/settings.png",
+                    "aria-label": "img-base-with-parent",
+                    className: "logo",
+                    alt: "Vite logo"
+                }]} description={<> From folder <Code>public2</Code></>}/>
+                <CardImage titleCard={"Image Symlink"} images={[{
+                    src: "/base/shared/images/change1.png",
+                    alt: "Vite logo",
+                    className: "logo",
+                    "aria-label": "logo-assets-symlink"
+                }]} description={<> File <Code>change1.png</Code> from folder <Code>shared-assets</Code></>}/>
+            </Grid>
         </>
     )
 }

--- a/packages/examples/react/src/CardImage.tsx
+++ b/packages/examples/react/src/CardImage.tsx
@@ -1,0 +1,29 @@
+import {ComponentProps, FC, ReactNode} from "react";
+import {Card, Grid, Text} from "@mantine/core";
+import {ColProps} from "@mantine/core/lib/Grid/Col/Col";
+
+interface IProps {
+    col?: ColProps;
+    titleCard: ReactNode;
+    description?: ReactNode;
+    images: ComponentProps<'img'>[];
+    children?: ReactNode;
+}
+
+export const CardImage: FC<IProps> = (props) => {
+    const {col, titleCard, images, description, children} = props;
+    return <Grid.Col span={6} {...col}>
+        <Card shadow="sm" padding="lg" radius="md" withBorder>
+            <Card.Section withBorder inheritPadding py="xs">
+                <Text fw={500}>{titleCard}</Text>
+            </Card.Section>
+            <Text mt="sm" c="dimmed" size="sm">
+                <Text span inherit c="var(--mantine-color-anchor)">
+                    {description}
+                </Text>
+            </Text>
+            {images.map((image, index) => <img key={index} {...image}/>)}
+            {children}
+        </Card>
+    </Grid.Col>
+};

--- a/packages/examples/react/src/index.css
+++ b/packages/examples/react/src/index.css
@@ -33,9 +33,7 @@ a:hover {
 body {
     margin: 0;
     display: flex;
-
     place-items: center;
-
     min-width: 320px;
     min-height: 100vh;
 }

--- a/packages/examples/react/src/index.css
+++ b/packages/examples/react/src/index.css
@@ -23,13 +23,19 @@ a {
 a:hover {
     color: #535bf2;
 }
-
+.bg-image{
+    background-image: url("/shared/images/sub-folder/sub-image.png");
+    background-repeat: no-repeat;
+    background-size: 50px;
+    background-position: top center;
+    height: 100%;
+}
 body {
     margin: 0;
     display: flex;
-    background-image: url("/shared/images/sub-folder/sub-image.png");
-    background-repeat: no-repeat;
+
     place-items: center;
+
     min-width: 320px;
     min-height: 100vh;
 }

--- a/packages/examples/react/src/index.css
+++ b/packages/examples/react/src/index.css
@@ -1,69 +1,76 @@
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+    font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+    line-height: 1.5;
+    font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+    color-scheme: light dark;
+    color: rgba(255, 255, 255, 0.87);
+    background-color: #242424;
 
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-text-size-adjust: 100%;
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+    font-weight: 500;
+    color: #646cff;
+    text-decoration: inherit;
 }
+
 a:hover {
-  color: #535bf2;
+    color: #535bf2;
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+    margin: 0;
+    display: flex;
+    background-image: url("/shared/images/sub-folder/sub-image.png");
+    background-repeat: no-repeat;
+    place-items: center;
+    min-width: 320px;
+    min-height: 100vh;
 }
 
 h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+    font-size: 3.2em;
+    line-height: 1.1;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    padding: 0.6em 1.2em;
+    font-size: 1em;
+    font-weight: 500;
+    font-family: inherit;
+    background-color: #1a1a1a;
+    cursor: pointer;
+    transition: border-color 0.25s;
 }
+
 button:hover {
-  border-color: #646cff;
+    border-color: #646cff;
 }
+
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+    outline: 4px auto -webkit-focus-ring-color;
 }
 
 @media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+    :root {
+        color: #213547;
+        background-color: #ffffff;
+    }
+
+    a:hover {
+        color: #747bff;
+    }
+
+    button {
+        background-color: #f9f9f9;
+    }
 }

--- a/packages/examples/react/vite.config.ts
+++ b/packages/examples/react/vite.config.ts
@@ -1,6 +1,6 @@
 import {PluginOption, defineConfig} from 'vite'
 import react from '@vitejs/plugin-react-swc'
-import DynamicPublicDirectory from "vite-multiple-assets";
+import {DynamicPublicDirectory} from "vite-multiple-assets";
 
 export default defineConfig({
     base: "/base/",
@@ -44,6 +44,7 @@ export default defineConfig({
                 watch: true, // default
             }, "public/**", "{\x01,public2}/**"], {
             ssr: false,
+            needTransformBaseCss: true, // because in index.css there is url of image to convert add base of vite before it
             followSymbolicLinks: true
         }) as PluginOption,
     ],

--- a/packages/examples/react/vite.config.ts
+++ b/packages/examples/react/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
             }, "public/**", "{\x01,public2}/**"], {
             ssr: false,
             needTransformBaseCss: true, // because in index.css there is url of image to convert add base of vite before it
-            followSymbolicLinks: true
+            followSymbolicLinks: true,
         }) as PluginOption,
     ],
 })

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-multiple-assets",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Multiple public asset directories for vite",
   "author": "Van nguyen ba tran",
   "license": "MIT",

--- a/packages/libs/src/build.ts
+++ b/packages/libs/src/build.ts
@@ -3,7 +3,7 @@ import type {NormalizedOutputOptions} from "rollup";
 import {basename, dirname, isAbsolute, join, resolve, sep} from "path";
 import mm from "micromatch";
 import fg from "fast-glob";
-import {FDst, IAssets, IConfig, IFilesMapper, IObjectAssets, IViteResolvedConfig} from "./types";
+import {FDst, IAssets, IConfig, IFilesMapper, IObjectAssets, IViteResolvedConfig, TReturnGetFile} from "./types";
 import {
     countParentDirectory,
     checkIsFolder,
@@ -109,7 +109,7 @@ export async function getFiles(
     opts: IConfig = {},
     viteConfig: IViteResolvedConfig,
     writeBundleOptions?: NormalizedOutputOptions
-) {
+): Promise<TReturnGetFile> {
     files_ = files_ || [];
     const {files: __transformFiles, data, watchPaths} = transformFiles(files_, opts);
     const cloneOpts = {...opts};
@@ -199,7 +199,7 @@ export async function buildMiddleWare(
     viteConfig: IViteResolvedConfig,
 ) {
     const {mapper} = await getFiles(assets, opts, viteConfig, writeBundleOptions);
-    for (const [_dstFile, filepath] of Object.entries(mapper)) {
+    for (const [_dstFile, filepath] of Object.entries(mapper!)) {
         const {output, path, root} = filepath!;
         // STUB: `dstFile` must be absolute.
         const dstFile = isAbsolute(_dstFile) ? _dstFile : join(opts.__dst!, output || _dstFile);

--- a/packages/libs/src/server.ts
+++ b/packages/libs/src/server.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import type {ICacheConfig, IConfig, IParameterViteServe, TValueMapper} from "./types";
+import type {ICacheConfig, IParameterViteServe, TValueMapper} from "./types";
 import mime from "mime-types";
 import http from "node:http";
 import type {IncomingMessage} from "http";
@@ -7,7 +7,7 @@ import {getFiles} from "./build";
 import {ViteDevServer} from "vite";
 import Watchpack from "watchpack"
 import {resolve} from "path";
-import {readSymlink} from "./utils";
+import {readSymlink, removeViteBase, replaceStartCharacter} from "./utils";
 
 
 const mimeTypes = {
@@ -92,22 +92,6 @@ function handleRestartChangFolder(watchPaths: string[], server: ViteDevServer) {
 
 }
 
-function removeViteBase(path: string, base: string) {
-    const regex = new RegExp(`/?${base}`);
-    return path.replace(regex, '');
-}
-
-function replaceStartCharacter(path: string, character: string) {
-    try {
-        if (path.startsWith(character)) {
-            return path.replace(character, "");
-        }
-        return path;
-    } catch (e) {
-        return path;
-    }
-
-}
 
 export async function ServerMiddleWare(payload: IParameterViteServe) {
     const {server, assets, options} = payload;
@@ -125,7 +109,7 @@ export async function ServerMiddleWare(payload: IParameterViteServe) {
             // NOTE: handle "%2E%2E/%2E%2E/some/file.txt" for relative backward "../../some/file.txt"
 
             const pathname = new URL(req.originalUrl ?? "", `http://${req.headers.host}`).pathname.slice(1);
-            let file = fileObject[removeViteBase(pathname, base)] ?? fileObject[removeViteBase(decodeURIComponent(pathname), base)];
+            let file = fileObject![removeViteBase(pathname, base)] ?? fileObject![removeViteBase(decodeURIComponent(pathname), base)];
 
             let path = file?.path!;
             if (file?.isSymLink) {

--- a/packages/libs/src/types.d.ts
+++ b/packages/libs/src/types.d.ts
@@ -28,6 +28,10 @@ export type TValueMapper = Pick<IObjectAssets, 'output'> & {
 export type IAssets = (string | IObjectAssets)[]; // | string | (IConfigExtend & { assets: string | string[]; })[];
 export type IFilesMapper = Partial<Record<string, TValueMapper>>; // STUB: { baseTransformedFilePath: toAbsolutePath }
 
+export type TReturnGetFile = {
+    mapper?: IFilesMapper;
+    watchPaths?: string[]
+}
 export type IMIME = Record<string, string>;
 
 /**
@@ -81,6 +85,7 @@ export interface IConfig extends IConfigExtend,
     mimeTypes?: IMIME;
     ssr?: boolean;
     cacheOptions?: ICacheConfig;
+    needTransformBaseCss?: boolean;
 }
 
 export interface IParameterViteServe {

--- a/packages/libs/src/utils/handleMatchFileFromAssets.ts
+++ b/packages/libs/src/utils/handleMatchFileFromAssets.ts
@@ -1,0 +1,18 @@
+import {replaceStartCharacter} from "./viteBase";
+import {replacePosixSep} from "./copyWithResolvedSymlinks";
+import {join} from "path";
+import {TReturnGetFile} from "../types";
+
+interface IProps {
+    viteBase: string;
+    url: string;
+    file: TReturnGetFile
+}
+
+export function handleMatchFileFromAssets(data: IProps) {
+    const {viteBase, url, file: file} = data;
+    const regex = new RegExp(`/?${viteBase}`);
+    const matchers = url.match(regex);
+    return !!(!matchers && file.mapper![replaceStartCharacter(url, '/')]);
+
+}

--- a/packages/libs/src/utils/index.ts
+++ b/packages/libs/src/utils/index.ts
@@ -4,3 +4,5 @@ export {checkIsFolder} from "./checkIsFolder"
 export {
     replacePosixSep, checkSymLink, readSymlink, copyWithResolvedSymlinks, findSymlinks
 } from "./copyWithResolvedSymlinks"
+export {replaceStartCharacter, removeViteBase} from "./viteBase"
+export {handleMatchFileFromAssets} from "./handleMatchFileFromAssets"

--- a/packages/libs/src/utils/viteBase.ts
+++ b/packages/libs/src/utils/viteBase.ts
@@ -1,0 +1,16 @@
+export function removeViteBase(path: string, base: string) {
+    const regex = new RegExp(`/?${base}`);
+    return path.replace(regex, '');
+}
+
+export function replaceStartCharacter(path: string, character: string) {
+    try {
+        if (path.startsWith(character)) {
+            return path.replace(character, "");
+        }
+        return path;
+    } catch (e) {
+        return path;
+    }
+
+}


### PR DESCRIPTION
# Problem
- Fix from issue #29 

`vite.config.ts`

```
export default defineConfig({
    base: "/base/",
    publicDir: false,
    plugins: [
        ...
        // if exclude shared-assets use ../../../shared-assets/**
        DynamicPublicDirectory([
            {
                input: "../../../shared-assets/**",
                output: "/shared/images",
                watch: true, // default
            }, "public/**", "{\x01,public2}/**"], {
            ssr: false,
            followSymbolicLinks: true
        }) as PluginOption,
    ],
})
```
`index.css`

```
body {
    margin: 0;
    display: flex;
    background-image: url("/shared/images/sub-folder/sub-image.png");
    background-repeat: no-repeat;
    place-items: center;
    min-width: 320px;
    min-height: 100vh;
}
```

With the above method, the background image will not be displayed. Users can make it visible by:

`background-image: url("/base/shared/images/sub-folder/sub-image.png");`

The problem is if `vite base` is dynamic. This will not satisfy user requirements

# Solution

- Add option `needTransformBaseCss`. Only apply CSS StyleSheets file

```
DynamicPublicDirectory([
            {
                input: "../../../shared-assets/**",
                output: "/shared/images",
                watch: true, // default
            }, "public/**", "{\x01,public2}/**"], {
            ssr: false,
            needTransformBaseCss: true, // because in index.css there is url of image to convert add base of vite before it
            followSymbolicLinks: true,
        })
```

Now, the background image will be available in two values, both of which will work:

`/base/shared/images/sub-folder/sub-image.png` or `/shared/images/sub-folder/sub-image.png`

